### PR TITLE
Single-page app easy routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ pushState applications as well as clean URLs and other goodies.
 Superstatic should be installed globally using npm:
 
     npm install -g superstatic
-    
+
 ## Usage
 
 By default, Superstatic will simply serve the current directory on port
 3474. This works just like any other static server:
 
     superstatic
-    
+
 You can optionally specify the directory, port and hostname of the server:
 
     superstatic public --port 8080 --host 127.0.0.1
-    
+
 Where it gets interesting is with Superstatic's JSON configuration file.
 
 ## Configuration
@@ -38,6 +38,9 @@ This configuration key specifies a directory *relative to the configuration file
 should be served. For example, if serving a Jekyll app, this might be set to `"_site"`.
 A directory passed as an argument into the command line app supercedes this configuration
 directive.
+
+**spa:** if `true`, `clean_urls` is forced to `true` (see below) and all requests without
+extensions are routed to `index.html`, as are requests with an `.html` extension.
 
 **clean_urls:** if `true`, all `.html` files will automatically have their extensions
 dropped. If `.html` is used at the end of a filename, it will perform a 301 redirect
@@ -167,7 +170,7 @@ var server = new Server({
 
 **environment:** an object containing values that are available to your app with when you add the script `<script src="/__/env.js"></script>` to your app. See [Using Environment Varaiables in Your App](http://docs.divshot.com/guides/environment-variables)
 
-**debug:** `true` or `false`. Enable or disable the output to the console for network requests. Defaults to `true` 
+**debug:** `true` or `false`. Enable or disable the output to the console for network requests. Defaults to `true`
 
 ## Instance methods
 

--- a/lib/server/middleware/clean_urls.js
+++ b/lib/server/middleware/clean_urls.js
@@ -5,11 +5,12 @@ var url = require('url');
 module.exports = function (settings) {
   return function (req, res, next) {
     if (!req.config) return next();
-    
+
     var pathname = url.parse(req.url).pathname;
     var root = req.config.root || settings.configuration.root || './';
     var filePath = path.join('/', root, pathname + '.html');
-    
+
+    if (req.config.spa) req.config.clean_urls = true;
     if (!req.config.clean_urls || pathname === '/') return next();
     if (isHtml(pathname)) return redirectAsCleanUrl(req, res);
     if (!isCleanUrl(pathname, settings)) return next();
@@ -21,11 +22,11 @@ module.exports = function (settings) {
 function redirectAsCleanUrl (req, res) {
   var pathname = url.parse(req.url).pathname;
   var query = qs.stringify(req.query);
-  
+
   var redirectUrl = (isDirectoryIndexFile(pathname, req.config.index))
     ? path.dirname(pathname)
     : path.join('/', path.dirname(pathname), path.basename(pathname.split('?')[0], '.html'));
-  
+
   redirectUrl += (query) ? '?' + query : '';
   res.writeHead(301, { Location: redirectUrl });
   res.end();

--- a/lib/server/middleware/custom_route.js
+++ b/lib/server/middleware/custom_route.js
@@ -3,22 +3,32 @@ var minimatch = require('minimatch');
 var slash = require('slasher');
 var globject = require('globject');
 var url = require('url');
+var _ = require('lodash');
 
 module.exports = function (settings) {
   return function (req, res, next) {
     if (!req.config) return next();
-    
+
+    if (req.config.spa) {
+      req.config.routes = _.extend(req.config.routes, {
+        "./!(*.*)": "/index.html",
+        "**/!(*.*)": "/index.html",
+        "./*.html": "/index.html",
+        "**/*.html": "/index.html"
+      });
+    }
+
     var pathname = url.parse(req.url).pathname;
     var routes = globject(slash(req.config.routes));
     var filePath = routes(slash(pathname));
-    
+
     if (!filePath) return next();
-    
+
     filePath = slash(settings.rootPathname(filePath));
     filePath = directoryIndex(filePath, req.config.index);
-    
+
     if (!settings.isFile(filePath)) return next();
-    
+
     res.send(filePath);
   };
 };
@@ -28,6 +38,6 @@ function directoryIndex (filePath, index) {
   if (filePath && path.extname(filePath) !== '.html') {
     filePath = path.join(slash(filePath), index);
   }
-  
+
   return filePath;
 }

--- a/test/server/middleware/clean_urls.js
+++ b/test/server/middleware/clean_urls.js
@@ -9,54 +9,65 @@ describe('clean urls middleware', function () {
   var settings;
   var server;
   var app;
-  
+
   beforeEach(function () {
     app = connect();
     settings = defaultSettings.create();
     settings.configuration.clean_urls = true;
-    
+
     app.use(function (req, res, next) {
       res.send = function (pathname) {
         res.writeHead(200);
         res.end(pathname);
       };
       req.config = settings.configuration;
-      
+
       next();
     });
   });
-  
+
   it('redirects to the clean url path when static html file is requested', function (done) {
     app.use(cleanUrls(settings));
-    
+
     request(app)
       .get('/superstatic.html')
       .expect('Location', '/superstatic')
       .expect(301)
       .end(done);
   });
-  
+
   it('it redirects and keeps the query string', function (done) {
     app.use(connect.query());
     app.use(cleanUrls(settings));
-    
+
     request(app)
       .get('/superstatic.html?key=value')
       .expect('Location', '/superstatic?key=value')
       .expect(301)
       .end(done);
   });
-  
+
+  it('serves a clean url if options.spa = true', function (done) {
+    settings.configuration.clean_urls = false;
+    settings.configuration.spa = true;
+    app.use(cleanUrls(settings));
+
+    request(app)
+      .get('/superstatic')
+      .expect('/superstatic.html')
+      .end(done);
+  });
+
   it('serves the .html version of the clean url if clean_urls are on', function (done) {
     app.use(cleanUrls(settings));
-    
+
     request(app)
       .get('/superstatic')
       .expect(200)
       .expect('/superstatic.html')
       .end(done);
   });
-  
+
   it('sets default root if no root is defined in config', function (done) {
     var app = connect()
       .use(function (req, res, next) {
@@ -68,13 +79,13 @@ describe('clean urls middleware', function () {
         next();
       })
       .use(cleanUrls(settings));
-      
+
     request(app)
       .get('/')
       .expect(404)
       .end(done);
   });
-  
+
   describe('skips middleware', function() {
     beforeEach(function () {
       app.use(function (req, res, next) {
@@ -84,44 +95,44 @@ describe('clean urls middleware', function () {
     });
     it('skips the middleware if clean_urls are turned off', function (done) {
       app.use(cleanUrls(settings));
-      
+
       request(app)
         .get('/superstatic.html')
         .expect(404)
         .end(done);
     });
-    
+
     it('skips the middleware if it is the root path', function (done) {
       app.use(cleanUrls(settings));
-      
+
       request(app)
         .get('/')
         .expect(404)
         .end(done);
     });
-    
+
     it('skips the middleware if it is not a file and clean_urls are on', function (done) {
       settings.isFile = function () {return false;}
-      
+
       app.use(function (req, res, next) {
         req.config.clean_urls = true;
         next();
       });
       app.use(cleanUrls(settings));
-      
+
       request(app)
         .get('/superstatic')
         .expect(404)
         .end(done);
     });
-    
+
     it('skips the middleware if there is no config available', function (done) {
       app.use(function (req, res, next) {
         delete req.config
         next();
       });
       app.use(cleanUrls(settings));
-      
+
       request(app)
         .get('/superstatic')
         .expect(404)

--- a/test/server/middleware/custom_route.js
+++ b/test/server/middleware/custom_route.js
@@ -10,106 +10,138 @@ var defaultRoutes = {
 
 describe('custom route middleware', function() {
   var app;
-  
+
   beforeEach(function () {
     app = connect();
     settings = defaultSettings.create();
     settings.configuration.routes = defaultRoutes
-    
+
     app.use(function (req, res, next) {
       res.send = function (pathname) {
         res.writeHead(200);
         res.end(pathname);
       }
       req.config = settings.configuration;
-      
+
       next();
     });
   });
-  
+
   it('serves the mapped route file for a custom route', function (done) {
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/test1')
       .expect(200)
       .expect('/index.html')
       .end(done);
   });
-  
+
   it('serves the index file of a directory if mapped route is mapped to a directory', function (done) {
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/test3')
       .expect(200)
       .expect('/test/dir/index.html')
       .end(done);
   });
-  
+
+  it('serves index.html if spa is on and route lacks extension', function (done) {
+    settings.configuration.spa = true;
+    app.use(customRoute(settings));
+
+    request(app)
+      .get('/test')
+      .expect(200)
+      .expect('/index.html')
+      .end(done);
+  });
+
+  it('serves index.html if spa is on and nested route lacks extension', function (done) {
+    settings.configuration.spa = true;
+    app.use(customRoute(settings));
+
+    request(app)
+      .get('/foo/test')
+      .expect(200)
+      .expect('/index.html')
+      .end(done);
+  });
+
+  it('404s if spa is on and route has extension that is not .html', function (done) {
+    settings.configuration.spa = true;
+    app.use(customRoute(settings));
+
+    request(app)
+      .get('/foo/test.foo')
+      .expect(404)
+      .end(done);
+  });
+
   it('serves the mapped route file for a custom route with a declared root', function (done) {
     app.use(function (req, res, next) {
       req.config.root = './public';
       next();
     });
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/test1')
       .expect(200)
       .expect('/public/index.html')
       .end(done);
   });
-  
+
   it('skips the middleware if there is no custom route', function (done) {
     settings.configuration.routes = {};
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/no-route')
       .expect(404)
       .end(done);
   });
-  
+
   it('skips the middleware if the custom route is for a file that does not exist', function (done) {
     settings.isFile = function () {return false;}
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/test1')
       .expect(404)
       .end(done);
   });
-  
+
   it('skips the middleware if there is no config available', function (done) {
     app.use(function (req, res, next) {
       delete req.config;
       next();
     });
     app.use(customRoute(settings));
-    
+
     request(app)
       .get('/test1')
       .expect(404)
       .end(done);
   });
-  
+
   describe('glob matching', function() {
     it('maps all paths to the same pathname', function (done) {
       settings.configuration.routes = {'**': 'index.html'};
       app.use(customRoute(settings));
-      
+
       request(app)
         .get('/any-route')
         .expect(200)
         .expect('/index.html')
         .end(done);
     });
-    
+
     it('maps all requests to files in a given directory to the same pathname', function (done) {
       settings.configuration.routes = {'subdir/**': 'index.html'};
       app.use(customRoute(settings));
-      
+
       request(app)
         .get('/subdir/anything/here')
         .expect(200)


### PR DESCRIPTION
Inspired by [this branch on carrot/charge](https://github.com/carrot/charge/tree/spa), this implements an `spa` configuration option which simply manipulates the configuration before the middleware chain is instantiated.  This is entirely for convenience.

Setting `spa` to `true` manipulates `clean_urls` and `custom_routes` to install a routing template for single-page applications:
- It forces `clean_urls` to `true`, and.
- It extends `routes` to include the following routes:
  
  ``` javascript
  {
    "./!(*.*)": "/index.html",
    "**/!(*.*)": "/index.html",
    "./*.html": "/index.html",
    "**/*.html": "/index.html"
  }
  ```
