### PR TITLE
'headers' section of config that follows routing rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ function superstatic (options) {
     app.use(middleware.redirect());
     app.use(middleware.removeTrailingSlash(app.settings));
     app.use(middleware.protect(app.settings));
+    app.use(middleware.headers(app.settings));
     app.use(middleware.sender(app.store));
     app.use(middleware.cacheControl());
     app.use(middleware.env(app.settings, app.localEnv));

--- a/lib/middleware/headers.js
+++ b/lib/middleware/headers.js
@@ -1,0 +1,22 @@
+var path = require('path');
+var minimatch = require('minimatch');
+var slash = require('slasher');
+var globject = require('globject');
+var url = require('url');
+
+module.exports = function (settings) {
+  return function (req, res, next) {
+    if (!req.config) return next();
+    
+    var pathname = url.parse(req.url).pathname;
+    var headersConfig = globject(slash(req.config.headers));
+    var headers = headersConfig(slash(pathname)) || {};
+    var key;
+
+    for (key in headers) {
+      res.setHeader(key, headers[key]);
+    }
+    
+    return next();
+  };
+};

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -12,3 +12,4 @@ exports.env = require('./env');
 exports.services = require('./services');
 exports.redirect = require('./redirect');
 exports.logger = require('./logger');
+exports.headers = require('./headers');

--- a/test/index.js
+++ b/test/index.js
@@ -189,15 +189,16 @@ describe('Superstatic server', function() {
     it('uses the reirect middleware', expectMiddleware(middleware.redirect(), 7));
     it('uses the trailing slash remover middleware', expectMiddleware(middleware.removeTrailingSlash(), 8));
     it('uses the basic auth protect middlware', expectMiddleware(middleware.protect(), 9));
-    it('uses the basic auth sender middlware', expectMiddleware(middleware.sender(), 10));
-    it('uses the cache control middleware', expectMiddleware(middleware.cacheControl(), 11));
-    it('uses the env middleware', expectMiddleware(middleware.env(), 12));
-    it('uses the clean urls middleware', expectMiddleware(middleware.cleanUrls(), 13));
-    it('uses the static middleware', expectMiddleware(middleware.static(), 14));
-    it('uses the custom route middleware', expectMiddleware(middleware.customRoute(), 15));
-    it('uses the default favicon middleware', expectMiddleware(favicon(path.resolve(__dirname, '../lib/templates/favicon.ico')), 16));
-    it('uses the not found middleware', expectMiddleware(middleware.notFound(), 17));
-    
+    it('uses the custom headers middleware', expectMiddleware(middleware.headers(), 10))
+    it('uses the basic auth sender middlware', expectMiddleware(middleware.sender(), 11));
+    it('uses the cache control middleware', expectMiddleware(middleware.cacheControl(), 12));
+    it('uses the env middleware', expectMiddleware(middleware.env(), 13));
+    it('uses the clean urls middleware', expectMiddleware(middleware.cleanUrls(), 14));
+    it('uses the static middleware', expectMiddleware(middleware.static(), 15));
+    it('uses the custom route middleware', expectMiddleware(middleware.customRoute(), 16));
+    it('uses the default favicon middleware', expectMiddleware(favicon(path.resolve(__dirname, '../lib/templates/favicon.ico')), 17));
+    it('uses the not found middleware', expectMiddleware(middleware.notFound(), 18));
+
     function expectMiddleware (fn, idx, done) {
       return function (done) {
         var server = superstatic();

--- a/test/middleware/custom_route.js
+++ b/test/middleware/custom_route.js
@@ -14,7 +14,7 @@ describe('custom route middleware', function() {
   beforeEach(function () {
     app = connect();
     settings = defaultSettings.create();
-    settings.configuration.routes = defaultRoutes
+    settings.configuration.routes = defaultRoutes;
     
     app.use(function (req, res, next) {
       res.send = function (pathname) {

--- a/test/middleware/headers.js
+++ b/test/middleware/headers.js
@@ -1,0 +1,69 @@
+var path = require('path');
+var connect = require('connect');
+var request = require('supertest');
+var headers = require('../../lib/middleware/headers');
+var defaultSettings = require('../../lib/settings/default');
+var defaultHeaders = {
+  '/test1': {
+    'Content-Type': 'mime/type'
+  },
+  '/test3': {
+    'Access-Control-Allow-Origin': 'https://www.example.net'
+  },
+  '/api/**': {
+    'Access-Control-Allow-Origin': '*'
+  }
+};
+
+function okay (req, res, next) {
+  res.writeHead(200);
+  res.end();
+}
+
+describe('cors middleware', function() {
+  var app;
+  
+  beforeEach(function () {
+    app = connect();
+    settings = defaultSettings.create();
+    settings.configuration.headers = defaultHeaders;
+    
+    app.use(function (req, res, next) {
+      req.config = settings.configuration;      
+      next();
+    });
+  });
+  
+  it('serves custom content types', function (done) {
+    app.use(headers(settings));
+    app.use(okay);
+
+    request(app)
+      .get('/test1')
+      .expect(200)
+      .expect('Content-Type', 'mime/type')
+      .end(done);
+  });
+  
+  it('serves custom access control headers', function (done) {
+    app.use(headers(settings));
+    app.use(okay);
+
+    request(app)
+      .get('/test3')
+      .expect(200)
+      .expect('Access-Control-Allow-Origin', 'https://www.example.net')
+      .end(done);
+  });
+  
+  it('uses routing rules', function (done) {
+    app.use(headers(settings));
+    app.use(okay);
+    
+    request(app)
+      .get('/api/whatever/you/wish')
+      .expect(200)
+      .expect('Access-Control-Allow-Origin', '*')
+      .end(done);
+  });
+});


### PR DESCRIPTION
Adds support for a section of the configuration:

``` json
{
  "headers": {
    "/test1": {
      "Content-Type": "mime/type"
    },
    "/test3": {
      "Access-Control-Allow-Origin": "https://www.example.net"
    },
    "/api/**": {
      "Access-Control-Allow-Origin": "*"
    }
  }
}
```

Sets headers when a request matches the route (same routing rules as custom routes)
