### PR TITLE
Urgent: Fix configuration parsing by replacing is-json with a try/catch

### DIFF
--- a/lib/settings/file.js
+++ b/lib/settings/file.js
@@ -35,10 +35,10 @@ ConfigFile.prototype.loadConfigurationFile = function (defaultConfig) {
   if (fs.existsSync(configFileName)) {
     config = fs.readFileSync(configFileName, 'utf8');
     
-    if (isValidJson(config)) {
+    try {
       config = JSON.parse(config);
     }
-    else {
+    catch (e) {
       throw new Error('Invalid JSON in config file');
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "slasher": "0.1.x",
     "update-notifier": "~0.1.8",
     "van": "0.0.4",
-    "is-json": "^1.1.3",
     "fast-url-parser": "^1.0.6-0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/joaquimserafim/is-json/commit/d5c8a429cc953119fde1fbae636d499733392f9c broke configuration parsing. I caught this because my Travis builds were failing because superstatic was complaining. superstatic's own tests fail as well with a fresh install. I've replaced is-json with a more conventional try/catch.

@joaquimserafim, just a heads up about this.

No disaster here since the breaking change was easy to catch and it's not like it would have ever made it into divshot in production. I think it's important though to do a review of the dependencies and what semver operator is appropriate for each. It was also a mistake to replace a try/catch with a two month old, sparsely tested library, especially when try/catch would be in all ways a better solution for this case. 

Please don't think I'm pissed off — I'm thoroughly grateful for superstatic. Being able to replicate divshot's server locally with one line of code is incredible. It's a big reason why I'm moving all my applications over to Divshot.
