### PR TITLE
Accept-Language root redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@
   * `--quiet` flag has been removed in favor of `--debug`
   * Gzip is off by default. Use the `--gzip` flag to enable.
 * **API**
-  * By default, Superstatic is a middleware now for an Express/Connect or barebones Node server. See the [API docs]() for more info on options for the middleware
-  * Since Superstatic gets required as a middleware by default now, this means that if you want Superstatic as a standalone server via the API, then you need to require the server via `var server = require('superstatic/lib/server');`. See the [API docs]() for options when instantiating the server.
+  * By default, Superstatic is a middleware now for an Express/Connect or barebones Node server. See the [API docs](https://github.com/divshot/superstatic#api) for more info on options for the middleware
+  * Since Superstatic gets required as a middleware by default now, this means that if you want Superstatic as a standalone server via the API, then you need to require the server via `var server = require('superstatic/lib/server');`. See the [API docs](https://github.com/divshot/superstatic#api) for options when instantiating the server.
   * `logger` options on server is no longer available. Since Superstatic can be required as a middleware and debug is off by default, you can inject your own logger.
   * `localEnv` is now `env` in middleware/server options
   * Server methods `listen()` and `close()` now behave like the bare/default Node http server methods.

--- a/lib/middleware/accept-language.js
+++ b/lib/middleware/accept-language.js
@@ -1,0 +1,25 @@
+var url = require('fast-url-parser');
+var locale = require('locale');
+
+module.exports = function (imports) {
+  
+  var languages = imports.languages;
+  var supportedLocales = new locale.Locales(languages);
+  locale.Locale["default"] = new locale.Locale(languages[0]);
+  
+  return function (req, res, next) {
+
+    var pathname = url.parse(req.url).pathname;
+
+    if (pathname === '/' && languages) {
+      var requestedLocales = new locale.Locales(req.headers["accept-language"]);
+      var matchingLocale = requestedLocales.best(supportedLocales);
+      res.__.redirect("/" + matchingLocale.language);
+
+    } else {
+
+      next();
+    }
+
+  };
+};

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,6 +1,7 @@
 exports.services = require('./services');
 exports.slashify = require('./slashify');
 exports.cleanUrls = require('./clean-urls');
+exports.acceptLanguage = require('./accept-language');
 exports.env = require('./env');
 exports.static = require('./static');
 exports.staticRouter = require('./static-router');

--- a/lib/superstatic.js
+++ b/lib/superstatic.js
@@ -79,6 +79,14 @@ module.exports = function (spec) {
   if (config.cache_control) {
     router.use(cacheControl(config.cache_control));
   }
+
+  if (config.languages) {
+    router.use(middleware.acceptLanguage({
+      languages: config.languages,
+      config: config,
+      provider: provider
+    }));
+  }
   
   // Clean urls
   if (config.clean_urls) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstatic",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Superstatic: a static file server for fancy apps",
   "main": "./lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "install": "^0.1.8",
     "jfig": "^1.2.0",
     "join-path": "^1.0.0",
+    "locale": "0.0.20",
     "lodash": "^3.1.0",
     "mime-types": "^2.0.4",
     "minimatch": "^2.0.1",

--- a/test/integration/accept-language.js
+++ b/test/integration/accept-language.js
@@ -1,0 +1,81 @@
+var fs = require('fs-extra');
+var _ = require('lodash');
+var connect = require('connect');
+var request = require('supertest');
+var expect = require('chai').expect;
+var query = require('connect-query');
+
+var superstatic = require('../../');
+
+var options = function () {
+  return {
+    config: {
+      root: '.tmp'
+    }
+  };
+};
+
+describe('accept language', function () {
+  
+  beforeEach(function () {
+    
+    fs.outputFileSync('.tmp/de/index.html', 'de index', 'utf8');
+    fs.outputFileSync('.tmp/en/index.html', 'en sub', 'utf8');
+  });
+  
+  afterEach(function () {
+
+    fs.removeSync('.tmp');
+  });
+  
+  it('redirects root to de if available', function (done) {
+    
+    var opts = options();
+    
+    opts.config.languages = ['en', 'de'];
+    
+    var app = connect()
+      .use(superstatic(opts));
+    
+    request(app)
+      .get('/')
+      .set('Accept-Language', 'de, en-gb;q=0.8, en;q=0.7')
+      .expect(301)
+      .expect('Location', '/de')
+      .end(done);
+  });
+
+  it('redirects root to first given if no language matches', function (done) {
+    
+    var opts = options();
+    
+    opts.config.languages = ['en', 'de'];
+    
+    var app = connect()
+      .use(superstatic(opts));
+    
+    request(app)
+      .get('/')
+      .set('Accept-Language', 'pl, hu;q=0.8')
+      .expect(301)
+      .expect('Location', '/en')
+      .end(done);
+  });
+
+it('redirects root to less preferred matches', function (done) {
+    
+    var opts = options();
+    
+    opts.config.languages = ['en', 'de'];
+    
+    var app = connect()
+      .use(superstatic(opts));
+    
+    request(app)
+      .get('/')
+      .set('Accept-Language', 'pl, de_DE;q=0.8')
+      .expect(301)
+      .expect('Location', '/de')
+      .end(done);
+  });
+});


### PR DESCRIPTION
Hey there,

I'd like to propose this little enhancement for redirecting from the root url to the best matching language based upon the accept language header and the configured available languages. I would love to see this on divshot as I am pretty much settled on hosting a project with you guys but this is a requirement I have (I do not want a client-side redirect root url for the language)

This is not meant for direct merging but rather as a proposal for an implementation. I am not much of a node person but based on some clues I got from the existing codebase I think this implementation matches the existing middlewares.

The way this works:

* Set a bunch of languages in `superstatic.json` using 'languages: ['en', 'de']`. The first given is the default
* When a request to root comes in and languages are configured, using the [locale](https://github.com/jed/locale) package try to figure out the best match and either redirect to that language subpath or the default

I think this simple setup covers the most common case of having multi-lingual sites since usually everything except the root will be namespaced within the selected locale and all deeplinks will point there.

As I said I wipped this up as a proof of concept, some things that may need further consideration:

* Is the config syntax flexible enough like this? Maybe for more complex cases an actual object might be required, i.e. like the redirection configs
* There should be a setup for the error pages to localize them too I guess.

Cheers