### PR TITLE
Document the `live` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Instantiates a Connect server, setting up Superstatic middleware, port, host, de
   * `errorPage` - A file path to a custom error page. Defaults to [Superstatic's error page](https://github.com/divshot/superstatic/blob/master/lib/assets/not_found.html).
   * `debug` - A boolean value that tells Superstatic to show or hide network logging in the console. Defaults to `false`.
   * `gzip` - A boolean value that tells Superstatic to gzip response body. Defaults to `false`.
+  * `live` - A boolean value. If set to `true`, Superstatic will watch all served files for changes – and reload open pages when a change occurs. Defaults to `false`.
 
 ## Run Tests
 


### PR DESCRIPTION
Hi, cool option – but I’ve only found it through reading the source! Should I mention it anywhere else than the readme?