### PR TITLE
Allow passing a glob to the `live` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Instantiates a Connect server, setting up Superstatic middleware, port, host, de
   * `errorPage` - A file path to a custom error page. Defaults to [Superstatic's error page](https://github.com/divshot/superstatic/blob/master/lib/assets/not_found.html).
   * `debug` - A boolean value that tells Superstatic to show or hide network logging in the console. Defaults to `false`.
   * `gzip` - A boolean value that tells Superstatic to gzip response body. Defaults to `false`.
+  * `live` - A boolean value. If set to `true`, Superstatic will watch all served files for changes – and reload open pages when a change occurs. Defaults to `false`.
 
 ## Run Tests
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Instantiates a Connect server, setting up Superstatic middleware, port, host, de
   * `errorPage` - A file path to a custom error page. Defaults to [Superstatic's error page](https://github.com/divshot/superstatic/blob/master/lib/assets/not_found.html).
   * `debug` - A boolean value that tells Superstatic to show or hide network logging in the console. Defaults to `false`.
   * `gzip` - A boolean value that tells Superstatic to gzip response body. Defaults to `false`.
-  * `live` - A boolean value. If set to `true`, Superstatic will watch all served files for changes – and reload open pages when a change occurs. Defaults to `false`.
+  * `live` - A boolean value or string. If set to `true`, Superstatic will watch all served files for changes – and reload open pages when a change occurs. If set to a [glob](https://github.com/isaacs/minimatch) string, it will only watch files matching the glob. Defaults to `false`.
 
 ## Run Tests
 

--- a/lib/cli/flags.js
+++ b/lib/cli/flags.js
@@ -53,9 +53,9 @@ module.exports = function (cli, options, done) {
   
   // TODO: test this
   cli.flag('--live', '-l')
-    .handler(function (isLive, done) {
+    .handler(function (glob, done) {
       
-      cli.set('live', true);
+      cli.set('live', glob);
       done();
     });
   

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,6 +36,7 @@ module.exports = function (spec) {
     // Install and load all services according
     // to config file
     loadServices(spec, function (err, appServices) {
+      var reloaderOptions;
       
       if (err) {
         throw err;
@@ -46,7 +47,9 @@ module.exports = function (spec) {
       
       // Start Live Reload server
       if (spec.live) {
-        reloader({app: app});
+        reloaderOptions = {app: app};
+        if (typeof spec.live === 'string') reloaderOptions.glob = spec.live;
+        reloader(reloaderOptions);
       }
       
       app.use(superstatic(spec));

--- a/lib/utils/reloader.js
+++ b/lib/utils/reloader.js
@@ -21,13 +21,14 @@ module.exports = function reloader (options) {
   
   var app = options.app;
   var port = options.port || 35729;
+  var glob = options.glob || '**/*.*';
   
   // Start live reload server
   tinylr().listen(port, function() {
     
     console.log('\n== Livereload listening on port %s. ==', port);
     
-    var watcher = chokidar.watch(process.cwd() + '/**/*.*');
+    var watcher = chokidar.watch(process.cwd() + '/' + glob);
     
     watcher.on('change', function (filepath) {
         


### PR DESCRIPTION
Hi, it often makes sense to watch only a relevant subset of files for changes. In this PR I’ve allowed passing a glob as well as a boolean to the `live` option.

You might prefer a more static API (i. e. don’t like an option to accept different types). I can move this functionality to another option.

I’ve only tested this functionality by hand. There are no existing tests for the LiveReload server and I’ve never written automated server tests from scratch.

This PR bases off #191.