### PR TITLE
[4.0] Fix how CLI picks up .env.json

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -7,6 +7,8 @@
 'use strict';
 
 var nash = require('nash');
+var fs = require('fs');
+var path = require('path');
 
 var PORT = 3474;
 var HOSTNAME = 'localhost';
@@ -15,6 +17,14 @@ var ENV_FILENAME = '.env.json';
 var DEBUG = false;
 var LIVE = false;
 
+var env;
+try {
+  env = JSON.parse(fs.readFileSync(path.resolve(ENV_FILENAME), 'utf8'));
+} catch (e) {
+  // do nothing
+}
+
+
 module.exports = function() {
   var cli = module.exports = nash();
 
@@ -22,7 +32,7 @@ module.exports = function() {
   cli.set('port', PORT);
   cli.set('hostname', HOSTNAME);
   cli.set('config', CONFIG_FILENAME);
-  cli.set('env', ENV_FILENAME);
+  cli.set('env', env);
   cli.set('debug', DEBUG);
   cli.set('live', LIVE);
 


### PR DESCRIPTION
There was a bug in how `.env.json` was used by the CLI that caused the env file not to be loaded. Now a `.env.json` is **only used by the CLI** and if you're using a middleware you have to manually pass env config. I think this is the behavior we want going forward.