### PR TITLE
Allow mismatched extensions when globbing rewrites.

### DIFF
--- a/lib/middleware/rewrites.js
+++ b/lib/middleware/rewrites.js
@@ -9,7 +9,6 @@
 var slasher = require('glob-slasher');
 var minimatch = require('minimatch');
 var urlParser = require('fast-url-parser');
-var path = require('path');
 
 var normalizeConfig = function(config) {
   return config || [];
@@ -33,11 +32,6 @@ module.exports = function() {
     var filepath = rewrites(slasher(pathname));
 
     if (!filepath) {
-      return next();
-    }
-
-    var ext = path.extname(pathname);
-    if (ext && ext !== path.extname(filepath)) {
       return next();
     }
 

--- a/test/unit/middleware/rewrites.spec.js
+++ b/test/unit/middleware/rewrites.spec.js
@@ -66,6 +66,21 @@ describe('static router', function() {
       .end(done);
   });
 
+  it('serves a route with an extension via a glob', function(done) {
+    app.use(rewrites({
+      rewrites: [{
+        source: '**', destination: '/index.html'
+      }]
+    }));
+
+    request(app)
+      .get('/my-route.py')
+      .expect(200)
+      .expect('index')
+      .expect('content-type', 'text/html; charset=utf-8')
+      .end(done);
+  });
+
   it('serves a negated route', function(done) {
     app.use(rewrites({
       rewrites: [{
@@ -94,7 +109,7 @@ describe('static router', function() {
       .end(done);
   });
 
-  it('ensures matching file extension', function(done) {
+  it('serves the mime type of the rewritten file', function(done) {
     app.use(rewrites({
       rewrites: [{
         source: '**', destination: '/index.html'
@@ -103,7 +118,7 @@ describe('static router', function() {
 
     request(app)
       .get('/index.js')
-      .expect(404)
+      .expect('content-type', 'text/html; charset=utf-8')
       .end(done);
   });
 


### PR DESCRIPTION
Previously, Superstatic disallowed a mismatch of URL to rewritten static asset. This prevents a valid use case of a URL that is an HTML representation of a non-HTML file, e.g. GitHub file browsing.

This PR removes the extension check and always serves the matched file. In addition, added a test to ensure that the mime type is taken from the static asset, not the file extension.