### PR TITLE
Don't allow fs provider to reach above root dir.

### DIFF
--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -9,18 +9,11 @@
 var crypto = require('crypto');
 var fs = require('fs');
 var pathjoin = require('join-path');
-var path = require('path');
 var RSVP = require('rsvp');
 var _ = require('lodash');
 
 var statPromise = RSVP.denodeify(fs.stat);
 var multiStat = function(paths) {
-  if (!paths.length) {
-    var error = new Error('Invalid path name');
-    error.code = 'ENOENT';
-    return RSVP.reject(error);
-  }
-
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
     stat.path = pathname;
@@ -74,18 +67,15 @@ module.exports = function(options) {
 
   return function(req, pathname) {
     pathname = decodeURI(pathname);
+    // jumping to parent directories is not allowed
+    if (pathname.indexOf('../') >= 0) {
+      return RSVP.resolve(null);
+    }
 
     var result = {};
     var foundPath;
     var fullPathnames = publicPaths.map(function(p) {
-      var bp = pathjoin(cwd, p);
-      var fp = pathjoin(cwd, p, pathname);
-      if (path.relative(bp, fp).indexOf('..') === 0) {
-        return null;
-      }
-      return fp;
-    }).filter(function(p) {
-      return !!p;
+      return pathjoin(cwd, p, pathname);
     });
 
     return multiStat(fullPathnames).then(function(stat) {

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -9,11 +9,18 @@
 var crypto = require('crypto');
 var fs = require('fs');
 var pathjoin = require('join-path');
+var path = require('path');
 var RSVP = require('rsvp');
 var _ = require('lodash');
 
 var statPromise = RSVP.denodeify(fs.stat);
 var multiStat = function(paths) {
+  if (!paths.length) {
+    var error = new Error('Invalid path name');
+    error.code = 'ENOENT';
+    return RSVP.reject(error);
+  }
+
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
     stat.path = pathname;
@@ -71,7 +78,14 @@ module.exports = function(options) {
     var result = {};
     var foundPath;
     var fullPathnames = publicPaths.map(function(p) {
-      return pathjoin(cwd, p, pathname);
+      var bp = pathjoin(cwd, p);
+      var fp = pathjoin(cwd, p, pathname);
+      if (path.relative(bp, fp).indexOf('..') === 0) {
+        return null;
+      }
+      return fp;
+    }).filter(function(p) {
+      return !!p;
     });
 
     return multiStat(fullPathnames).then(function(stat) {

--- a/test/integration/serving-files.spec.js
+++ b/test/integration/serving-files.spec.js
@@ -28,6 +28,7 @@ describe('serves', function() {
     fs.outputFileSync('.tmp/app.js', 'console.log("js")', 'utf-8');
     fs.outputFileSync('.tmp/dir/index.html', 'dir index', 'utf-8');
     fs.outputFileSync('.tmp/dir/sub.html', 'dir sub', 'utf-8');
+    fs.outputFileSync('.tmp/File With Spaces.html', 'spaces', 'utf-8');
   });
 
   afterEach(function() {
@@ -49,6 +50,30 @@ describe('serves', function() {
   });
 
   it('directory index file', function(done) {
+    var opts = options();
+
+    var app = connect()
+      .use(superstatic(opts));
+
+    request(app)
+      .get('/dir/')
+      .expect(200)
+      .expect('dir index')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .end(done);
+  });
+
+  it('cannot access files above the root', function(done) {
+    var app = connect()
+      .use(superstatic(options()));
+
+    request(app)
+      .get('/../README.md')
+      .expect(404)
+      .end(done);
+  });
+
+  it('file with spaces', function(done) {
     var opts = options();
 
     var app = connect()

--- a/test/integration/serving-files.spec.js
+++ b/test/integration/serving-files.spec.js
@@ -28,7 +28,6 @@ describe('serves', function() {
     fs.outputFileSync('.tmp/app.js', 'console.log("js")', 'utf-8');
     fs.outputFileSync('.tmp/dir/index.html', 'dir index', 'utf-8');
     fs.outputFileSync('.tmp/dir/sub.html', 'dir sub', 'utf-8');
-    fs.outputFileSync('.tmp/File With Spaces.html', 'spaces', 'utf-8');
   });
 
   afterEach(function() {

--- a/test/integration/serving-files.spec.js
+++ b/test/integration/serving-files.spec.js
@@ -73,20 +73,6 @@ describe('serves', function() {
       .end(done);
   });
 
-  it('file with spaces', function(done) {
-    var opts = options();
-
-    var app = connect()
-      .use(superstatic(opts));
-
-    request(app)
-      .get('/dir/')
-      .expect(200)
-      .expect('dir index')
-      .expect('Content-Type', 'text/html; charset=utf-8')
-      .end(done);
-  });
-
   it('missing directory index', function(done) {
     var opts = options();
 


### PR DESCRIPTION
This change makes it so that the fs provider cannot serve files above the specified root. Previously, a string of `../../../` would let you access files outside the specified public directory.