### PR TITLE
Updating dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,11 +143,10 @@
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": 2,            // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-comment": 2,             // http://eslint.org/docs/rules/spaced-comment
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - 0.10
   - 0.12
+  - 4
   - stable
 
 # script:

--- a/lib/middleware/clean-urls.js
+++ b/lib/middleware/clean-urls.js
@@ -57,7 +57,7 @@ module.exports = function() {
       return redirectAsCleanUrl(req, res);
     }
 
-    res.superstatic.handle([
+    return res.superstatic.handle([
       pathutils.asDirectoryIndex(pathname),
       pathname + '.html'
     ], next);

--- a/lib/middleware/env.js
+++ b/lib/middleware/env.js
@@ -30,6 +30,6 @@ module.exports = function(spec) {
       return undefined;
     }
 
-    next();
+    return next();
   };
 };

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -38,7 +38,7 @@ module.exports = function() {
     var fallbackPath = hasTrailingSlash ? pathname : indexPathname;
     var noresultRedirect = hasTrailingSlash ? withoutTrailingSlash : withTrailingSlash;
 
-    res.superstatic.provider(req, fetchPath).then(function(result) {
+    return res.superstatic.provider(req, fetchPath).then(function(result) {
       if (result) {
         return res.superstatic.handleFileStream({file: fetchPath}, result);
       }
@@ -48,7 +48,7 @@ module.exports = function() {
           return res.superstatic.handle({redirect: noresultRedirect});
         }
 
-        next();
+        return next();
       });
     }).catch(function(err) {
       res.superstatic.handleError(err);

--- a/lib/middleware/headers.js
+++ b/lib/middleware/headers.js
@@ -16,7 +16,7 @@ var normalizedConfigHeaders = function(spec, config) {
   var out = config || [];
   if (_.isArray(config)) {
     var _isAllowed = function(headerToSet) {
-      return _.contains(spec.allowedHeaders, headerToSet.key.toLowerCase());
+      return _.includes(spec.allowedHeaders, headerToSet.key.toLowerCase());
     };
 
     for (var i = 0; i < config.length; i++) {

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -65,6 +65,7 @@ Redirect.prototype.test = function(url) {
       destination: this.destination
     };
   }
+  return undefined;
 };
 
 module.exports = function() {
@@ -88,6 +89,7 @@ module.exports = function() {
         var result = redirects[i].test(url);
         if (result) { return result; }
       }
+      return undefined;
     };
 
     var match = matcher(req.url);
@@ -99,7 +101,7 @@ module.exports = function() {
     // Remove leading slash of a url
     var redirectUrl = formatExternalUrl(match.destination);
 
-    res.superstatic.handle({
+    return res.superstatic.handle({
       redirect: redirectUrl,
       status: match.type
     });

--- a/lib/middleware/rewrites.js
+++ b/lib/middleware/rewrites.js
@@ -21,6 +21,7 @@ var matcher = function(rewrites) {
         return rewrites[i].destination;
       }
     }
+    return undefined;
   };
 };
 
@@ -36,6 +37,6 @@ module.exports = function() {
     }
 
     res.statusCode = 200;
-    res.superstatic.handle(filepath, next);
+    return res.superstatic.handle(filepath, next);
   };
 };

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -61,7 +61,7 @@ module.exports = function(options) {
       });
 
       // read all file and pipe it (write it) to the hash object
-      fd.pipe(hash);
+      return fd.pipe(hash);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "concat-stream": "^1.5.1",
-    "eslint": "^1.8.0",
+    "eslint": "^2.9.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.0.1",
     "nsp": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "as-array": "^2.0.0",
-    "async": "^1.2.1",
+    "async": "^1.5.2",
     "basic-auth-connect": "^1.0.0",
     "chalk": "^1.0.0",
     "char-spinner": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "coverage": "istanbul cover --print detail ./node_modules/.bin/_mocha -- test/unit/** test/integration/**",
     "outdated": "npm outdated --depth 0",
-    "audit": "npm shrinkwrap --dev && nsp audit-shrinkwrap || true && rm npm-shrinkwrap.json",
+    "audit": "npm shrinkwrap --dev && nsp check || true && rm npm-shrinkwrap.json",
     "watch": "mocha -w test/unit/** test/integration/**"
   },
   "author": "Firebase (https://www.firebase.com/)",
@@ -39,7 +39,7 @@
     "hashbang"
   ],
   "dependencies": {
-    "as-array": "^1.0.0",
+    "as-array": "^2.0.0",
     "async": "^1.2.1",
     "basic-auth-connect": "^1.0.0",
     "chalk": "^1.0.0",
@@ -50,15 +50,15 @@
     "connect-query": "^0.2.0",
     "destroy": "^1.0.3",
     "fast-url-parser": "^1.1.3",
-    "fs-extra": "^0.20.0",
-    "glob": "^5.0.3",
+    "fs-extra": "^0.30.0",
+    "glob": "^7.0.3",
     "glob-slasher": "^1.0.1",
     "home-dir": "^1.0.0",
     "is-url": "^1.2.1",
     "join-path": "^1.0.0",
     "lodash": "^3.1.0",
     "mime-types": "^2.0.4",
-    "minimatch": "^2.0.1",
+    "minimatch": "^3.0.0",
     "morgan": "^1.5.0",
     "nash": "^2.0.0",
     "on-finished": "^2.2.0",
@@ -68,7 +68,7 @@
     "rsvp": "^3.1.0",
     "string-length": "^1.0.0",
     "try-require": "^1.0.0",
-    "update-notifier": "0.3.2"
+    "update-notifier": "^0.7.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",
@@ -77,7 +77,7 @@
     "eslint": "^1.8.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.0.1",
-    "nsp": "^1.0.0",
+    "nsp": "^2.4.0",
     "request": "^2.51.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "join-path": "^1.0.0",
     "lodash": "^4.11.2",
     "mime-types": "^2.0.4",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.2",
     "morgan": "^1.5.0",
     "nash": "^2.0.0",
     "on-finished": "^2.2.0",
@@ -68,7 +68,7 @@
     "rsvp": "^3.1.0",
     "string-length": "^1.0.0",
     "try-require": "^1.0.0",
-    "update-notifier": "^0.7.0"
+    "update-notifier": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "home-dir": "^1.0.0",
     "is-url": "^1.2.1",
     "join-path": "^1.0.0",
-    "lodash": "^3.1.0",
+    "lodash": "^4.11.2",
     "mime-types": "^2.0.4",
     "minimatch": "^3.0.0",
     "morgan": "^1.5.0",


### PR DESCRIPTION
Updating some dependencies, but it still doesn't get rid of all the warnings. Have to wait for a new patch of mocha ([commit](https://github.com/mochajs/mocha/commit/c9bcfc1b015c8d15d5fe5159e30818cd02f6a098)) for the install errors to go away completely