### PR TITLE
Make compatible with (new) firebase.json

### DIFF
--- a/lib/loaders/config-file.js
+++ b/lib/loaders/config-file.js
@@ -49,6 +49,7 @@ module.exports = function(filename) {
   if (_.isString(filename) && _.endsWith(filename, 'json')) {
     try {
       config = JSON.parse(fs.readFileSync(path.resolve(filename)));
+      config = config.hosting ? config.hosting : config;
     } catch (e) {
       // do nothing
     }


### PR DESCRIPTION
The `superstatic` CLI tool expects `firebase.json` to be in a format that's incompatible with the format expected by `firebase` itself. This PR applies the same "tweak" to the config file handling [that `serve.js` does](https://github.com/firebase/firebase-tools/blob/master/commands/serve.js#L23) so that the two are compatible.