### PR TITLE
Redirects preserve query parameters.

### DIFF
--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -21,6 +21,15 @@ function formatExternalUrl(u) {
   return (isUrl(cleaned)) ? cleaned : u;
 }
 
+function addQuery(url, qs) {
+  if (url.indexOf('?') >= 0) {
+    return url + '&' + qs;
+  } else if (qs && qs.length) {
+    return url + '?' + qs;
+  }
+  return url;
+}
+
 var Redirect = function(source, destination, type) {
   this.type = type || 301;
   this.source = slasher(source);
@@ -38,7 +47,7 @@ Redirect.prototype.test = function(url) {
   if (url.indexOf('?') > 0) {
     var parts = url.split('?');
     url = parts[0];
-    qs = '?' + parts[1];
+    qs = parts[1];
   }
 
   var match;
@@ -58,10 +67,9 @@ Redirect.prototype.test = function(url) {
 
     try {
       var dest = this.compileDestination(params);
-
       return {
         type: this.type,
-        destination: dest + qs
+        destination: addQuery(dest, qs)
       };
     } catch (e) {
       return undefined;
@@ -69,7 +77,7 @@ Redirect.prototype.test = function(url) {
   } else if (minimatch(url, this.source)) {
     return {
       type: this.type,
-      destination: this.destination + qs
+      destination: addQuery(this.destination, qs)
     };
   }
   return undefined;

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -34,6 +34,13 @@ var Redirect = function(source, destination, type) {
 };
 
 Redirect.prototype.test = function(url) {
+  var qs = '';
+  if (url.indexOf('?') > 0) {
+    var parts = url.split('?');
+    url = parts[0];
+    qs = '?' + parts[1];
+  }
+
   var match;
   if (this.capture) {
     match = this.capture.exec(url);
@@ -54,7 +61,7 @@ Redirect.prototype.test = function(url) {
 
       return {
         type: this.type,
-        destination: dest
+        destination: dest + qs
       };
     } catch (e) {
       return undefined;
@@ -62,7 +69,7 @@ Redirect.prototype.test = function(url) {
   } else if (minimatch(url, this.source)) {
     return {
       type: this.type,
-      destination: this.destination
+      destination: this.destination + qs
     };
   }
   return undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstatic",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A static file server for fancy apps",
   "main": "./lib",
   "scripts": {

--- a/test/unit/middleware/redirects.spec.js
+++ b/test/unit/middleware/redirects.spec.js
@@ -229,6 +229,21 @@ describe('redirect middleware', function() {
       .end(done);
   });
 
+  it('appends query params to the destination when redirecting', function(done) {
+    var app = connect()
+      .use(setup).use(redirect({redirects: [{
+        source: '/source',
+        destination: '/destination?hello=world',
+        type: 301
+      }]}));
+
+    request(app)
+      .get('/source?foo=bar&baz=qux')
+      .expect(301)
+      .expect('Location', '/destination?hello=world&foo=bar&baz=qux')
+      .end(done);
+  });
+
   it('preserves query params when redirecting to external urls', function(done) {
     var app = connect()
       .use(setup).use(redirect({redirects: [{

--- a/test/unit/middleware/redirects.spec.js
+++ b/test/unit/middleware/redirects.spec.js
@@ -106,7 +106,7 @@ describe('redirect middleware', function() {
       .end(done);
   });
 
-  it('redirects using segements in the url path', function(done) {
+  it('redirects using segments in the url path', function(done) {
     var app = connect()
       .use(setup)
       .use(redirect({redirects: [{
@@ -211,6 +211,51 @@ describe('redirect middleware', function() {
       .get('/source')
       .expect(301)
       .expect('Location', 'https://redirectedto.com')
+      .end(done);
+  });
+
+  it('preserves query params when redirecting', function(done) {
+    var app = connect()
+      .use(setup).use(redirect({redirects: [{
+        source: '/source',
+        destination: '/destination',
+        type: 301
+      }]}));
+
+    request(app)
+      .get('/source?foo=bar&baz=qux')
+      .expect(301)
+      .expect('Location', '/destination?foo=bar&baz=qux')
+      .end(done);
+  });
+
+  it('preserves query params when redirecting to external urls', function(done) {
+    var app = connect()
+      .use(setup).use(redirect({redirects: [{
+        source: '/source',
+        destination: 'http://example.com/destination',
+        type: 301
+      }]}));
+
+    request(app)
+      .get('/source?foo=bar&baz=qux')
+      .expect(301)
+      .expect('Location', 'http://example.com/destination?foo=bar&baz=qux')
+      .end(done);
+  });
+
+  it('preserves query params when redirecting with captures', function(done) {
+    var app = connect()
+      .use(setup).use(redirect({redirects: [{
+        source: '/source/:foo',
+        destination: '/:foo/bar',
+        type: 301
+      }]}));
+
+    request(app)
+      .get('/source/wat?foo=bar&baz=qux')
+      .expect(301)
+      .expect('Location', '/wat/bar?foo=bar&baz=qux')
       .end(done);
   });
 });


### PR DESCRIPTION
This updates redirects to properly match and redirect when a query string is present, preserving the query string. It explicitly **does not**:

1. Allow matching based on query strings
2. Allow captures to be inserted into query strings