### PR TITLE
Add extensible rewriters

### DIFF
--- a/lib/middleware/rewrites.js
+++ b/lib/middleware/rewrites.js
@@ -18,7 +18,7 @@ var matcher = function(rewrites) {
   return function(url) {
     for (var i = 0; i < rewrites.length; i++) {
       if (minimatch(url, rewrites[i].source)) {
-        return rewrites[i].destination;
+        return rewrites[i];
       }
     }
     return undefined;
@@ -30,13 +30,14 @@ module.exports = function() {
     var rewrites = matcher(normalizeConfig(req.superstatic.rewrites));
 
     var pathname = urlParser.parse(req.url).pathname;
-    var filepath = rewrites(slasher(pathname));
+    var match = rewrites(slasher(pathname));
 
-    if (!filepath) {
+    if (!match) {
       return next();
     }
 
     res.statusCode = 200;
-    return res.superstatic.handle(filepath, next);
+
+    return res.superstatic.handle({rewrite: match}, next);
   };
 };

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -19,6 +19,7 @@ var Responder = function(req, res, options) {
   this.res = res;
   this.provider = options.provider;
   this.config = options.config || {};
+  this.rewriters = options.rewriters || {};
   this.gzip = options.gzip;
 };
 
@@ -51,18 +52,24 @@ Responder.prototype.handle = function(item, next) {
 };
 
 Responder.prototype._handle = function(item) {
+  console.log(_.isFunction(item));
   if (_.isArray(item)) {
     return this.handleStack(item);
   } else if (_.isString(item)) {
     return this.handleFile({file: item});
-  } else if (_.isObject(item)) {
+  } else if (_.isPlainObject(item)) {
     if (item.file) {
       return this.handleFile(item);
     } else if (item.redirect) {
       return this.handleRedirect(item);
+    } else if (item.rewrite) {
+      return this.handleRewrite(item);
     } else if (item.data) {
       return this.handleData(item);
     }
+  } else if (_.isFunction(item)) {
+    console.log('i am here');
+    return this.handleMiddleware(item);
   }
 
   return RSVP.reject(new Error(JSON.stringify(item) + ' is not a recognized responder directive'));
@@ -142,6 +149,29 @@ Responder.prototype.handleRedirect = function(redirect) {
   this.res.setHeader('Content-Type', 'text/html; charset=utf-8');
   this.res.end('Redirecting to ' + redirect.redirect);
   return RSVP.resolve(true);
+};
+
+Responder.prototype.handleMiddleware = function(middleware) {
+  var self = this;
+  return new RSVP.Promise(function(resolve) {
+    middleware(self.req, self.res, function() { resolve(false); });
+  });
+};
+
+Responder.prototype.handleRewrite = function(item) {
+  var self = this;
+  if (item.rewrite.destination) {
+    return self.handleFile({file: item.rewrite.destination});
+  }
+
+  for (var key in this.rewriters) {
+    if (item.rewrite[key]) {
+      return this.rewriters[key](item.rewrite, this).then(function(result) {
+        return self._handle(result);
+      });
+    }
+  }
+  return RSVP.reject(new Error('Unable to find a matching rewriter for ' + JSON.stringify(item.rewrite)));
 };
 
 Responder.prototype.handleData = function(data) {

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -52,7 +52,6 @@ Responder.prototype.handle = function(item, next) {
 };
 
 Responder.prototype._handle = function(item) {
-  console.log(_.isFunction(item));
   if (_.isArray(item)) {
     return this.handleStack(item);
   } else if (_.isString(item)) {
@@ -68,7 +67,6 @@ Responder.prototype._handle = function(item) {
       return this.handleData(item);
     }
   } else if (_.isFunction(item)) {
-    console.log('i am here');
     return this.handleMiddleware(item);
   }
 

--- a/lib/superstatic.js
+++ b/lib/superstatic.js
@@ -49,7 +49,8 @@ var superstatic = function(spec) {
     res.superstatic = new Responder(req, res, {
       provider: provider,
       config: config,
-      gzip: spec.gzip
+      gzip: spec.gzip,
+      rewriters: spec.rewriters
     });
 
     next();

--- a/test/unit/responder.spec.js
+++ b/test/unit/responder.spec.js
@@ -57,6 +57,13 @@ describe('Responder', function() {
       responder.handle(obj);
       expect(stub).to.have.been.calledWith(obj);
     });
+
+    it('should call through to handleRewrite with a rewrite object', function() {
+      var stub = sinon.stub(responder, 'handleRewrite').returns(RSVP.resolve(true));
+      var obj = {rewrite: {}};
+      responder.handle(obj);
+      expect(stub).to.have.been.calledWith(obj);
+    });
   });
 
   describe('#_handle', function() {
@@ -67,6 +74,29 @@ describe('Responder', function() {
     it('should reject with an unrecognized payload', function() {
       return expect(responder._handle({foo: 'bar'})).to.be.rejectedWith('is not a recognized responder directive');
     });
+  });
+
+  describe('#handleRewrite', function() {
+    it('should call through to a registered custom rewriter', function() {
+      var out;
+      responder = new Responder({}, {setHeader: _.noop, end: function(data) { out = data; }}, {
+        rewriters: {
+          message: function(rewrite) {
+            return RSVP.resolve({data: rewrite.message, contentType: 'text/plain', status: 200});
+          }
+        }
+      });
+
+      return responder.handleRewrite({rewrite: {message: 'hi'}}).then(function(result) {
+        expect(result).to.be.true;
+        expect(out).to.equal('hi');
+      });
+    });
+  });
+
+  describe('#handleMiddleware', function() {
+    xit('should call the middleware');
+    xit('should resolve false if next() is called');
   });
 
   describe('#handleFile', function() {

--- a/test/unit/responder.spec.js
+++ b/test/unit/responder.spec.js
@@ -95,8 +95,25 @@ describe('Responder', function() {
   });
 
   describe('#handleMiddleware', function() {
-    xit('should call the middleware');
-    xit('should resolve false if next() is called');
+    var rq;
+    beforeEach(function() {
+      rq = {};
+      responder = new Responder(rq, {setHeader: _.noop, end: _.noop}, {});
+    });
+
+    it('should call the middleware', function(done) {
+      responder.handleMiddleware(function() {
+        done();
+      });
+    });
+
+    it('should resolve false if next is called', function() {
+      return responder.handleMiddleware(function(req, res, next) {
+        next();
+      }).then(function(result) {
+        expect(result).to.be.false;
+      });
+    });
   });
 
   describe('#handleFile', function() {


### PR DESCRIPTION
Adds the ability to define custom rewriters that handle keys other than `destination` in configuration. A rewriter should return a Promise that resolves to something that `Responder.prototype.handle` can...handle.