### PR TITLE
Urgent update: of update-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rsvp": "^3.6.2",
     "string-length": "^1.0.0",
     "try-require": "^1.0.0",
-    "update-notifier": "^1.0.3"
+    "update-notifier": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
The replaced version of update-notifier did not allow you to use the latest version of node (8+) because it required nodejs < 7

This was preventing people with the latest version of node from installing firebase-tools

Recommend updating firebase-tools->superstatic dep after this PR