### PR TITLE
replaced slasher functionality

### DIFF
--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -11,7 +11,6 @@ var _ = require('lodash');
 
 var minimatch = require('minimatch');
 var pathToRegexp = require('path-to-regexp');
-var slasher = require('glob-slasher');
 
 function formatExternalUrl(u) {
   var cleaned = u
@@ -32,10 +31,28 @@ function addQuery(url, qs) {
 
 var Redirect = function(source, destination, type) {
   this.type = type || 301;
-  this.source = slasher(source);
+
+  // no leading slash
+  if(source[0] != '/')
+  {
+    // glob pattern but no leading slash
+    if(source[0] == '!' && source[1] != '/')
+    {
+      this.source = '!/' + source.substring(2);
+    }
+    else
+    {
+      this.source = '/' + source;
+    }
+  }
+  else
+  {
+    this.source = source;
+  }
+
   this.destination = destination;
 
-  if (this.destination.match(/(?:^|\/):/)) {
+  if (this.source.match(/(?:^|\/):/)) {
     this.captureKeys = [];
     this.capture = pathToRegexp(this.source, this.captureKeys);
     this.compileDestination = pathToRegexp.compile(this.destination);
@@ -51,9 +68,11 @@ Redirect.prototype.test = function(url) {
   }
 
   var match;
+
   if (this.capture) {
     match = this.capture.exec(url);
   }
+
   if (match) {
     var params = {};
     for (var i = 0; i < this.captureKeys.length; i++) {

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -33,12 +33,11 @@ var Redirect = function(source, destination, type) {
   this.type = type || 301;
 
   // no leading slash
-  if (source[0] != '/') {
+  if (source[0] !== '/') {
     // glob pattern but no leading slash
-    if (source[0] == '!' && source[1] != '/') {
+    if (source[0] === '!' && source[1] !== '/') {
       this.source = '!/' + source.substring(2);
-    }
-    else {
+    } else {
       this.source = '/' + source;
     }
   }

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -40,9 +40,7 @@ var Redirect = function(source, destination, type) {
     } else {
       this.source = '/' + source;
     }
-  }
-  else
-  {
+  } else {
     this.source = source;
   }
 

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -33,15 +33,12 @@ var Redirect = function(source, destination, type) {
   this.type = type || 301;
 
   // no leading slash
-  if(source[0] != '/')
-  {
+  if (source[0] != '/') {
     // glob pattern but no leading slash
-    if(source[0] == '!' && source[1] != '/')
-    {
+    if (source[0] == '!' && source[1] != '/') {
       this.source = '!/' + source.substring(2);
     }
-    else
-    {
+    else {
       this.source = '/' + source;
     }
   }

--- a/lib/middleware/redirects.js
+++ b/lib/middleware/redirects.js
@@ -35,7 +35,7 @@ var Redirect = function(source, destination, type) {
   // no leading slash
   if (source[0] !== '/') {
     // glob pattern but no leading slash
-    if (source[0] === '!' && source[1] !== '/') {
+    if (source[0] === '!' && source[1] && source[1] !== '/') {
       this.source = '!/' + source.substring(2);
     } else {
       this.source = '/' + source;


### PR DESCRIPTION
Fixes the issue encountered in #231.

[`glob-slasher`](https://github.com/scottcorgan/glob-slasher) replaces `/`s in the source with `\`s (at least on Windows) which results in URLs not matching against the given `source` pattern.  
For example the following source `/embed/:id/:ft` is transformed into `\embed\:id\:ft` which fails the following condition `this.source.match(/(?:^|\/):/)`.

This commit passes all tests in `test/unit/middleware/redirects.spec.js` so I think I have covered all three cases for the source:
1. source starts with `/` | do nothing
2. source starts with `!` but does not have a leading slash | add slash after `!`
3. source does not have a leading slash | add a leading slash