### PR TITLE
Shouldn't redirect to an empty string

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Do not redirect to an empty string

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -11,8 +11,8 @@ var pathutils = require('../utils/pathutils');
 var _ = require('lodash');
 
 // We cannot redirect to "", redirect to "/" instead
-function noEmptyRedirect(redir) {
-  return {redirect: !redir.redirect ? '/' : redir.redirect};
+function normalizeRedirectPath(path) {
+  return path || '/';
 }
 
 module.exports = function() {
@@ -40,7 +40,7 @@ module.exports = function() {
             if (trailingSlashBehavior === true) {
               redirPath = pathutils.addTrailingSlash(redirPath);
             }
-            return res.superstatic.handle(noEmptyRedirect({redirect: redirPath + search}));
+            return res.superstatic.handle({redirect: normalizeRedirectPath(redirPath + search)});
           }
         }
         return res.superstatic.handleFileStream({file: pathname}, result);
@@ -62,7 +62,7 @@ module.exports = function() {
           if (trailingSlashBehavior === false &&
               hasTrailingSlash &&
               pathname !== '/') { // No infinite redirects
-            return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingSlash(pathname) + search}));
+            return res.superstatic.handle({redirect: normalizeRedirectPath(pathutils.removeTrailingSlash(pathname) + search)});
           }
           if (trailingSlashBehavior === true &&
               !hasTrailingSlash) {
@@ -93,7 +93,7 @@ module.exports = function() {
                   hasTrailingSlash) {
                 // If we had a slash to begin with, and we could be serving a file without it, we'll remove the slash.
                 // (This works because we are in the cleanURL block.)
-                return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingSlash(pathname) + search}));
+                return res.superstatic.handle({redirect: normalizeRedirectPath(pathutils.removeTrailingSlash(pathname) + search)});
               }
               if (trailingSlashBehavior === true &&
                   !hasTrailingSlash) {
@@ -104,7 +104,7 @@ module.exports = function() {
               }
               // If we've gotten this far and still have `/index.html` on the end, we want to remove it from the URL.
               if (_.endsWith(appendedPath, '/index.html')) {
-                return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingString(appendedPath, '/index.html') + search}));
+                return res.superstatic.handle({redirect: normalizeRedirectPath(pathutils.removeTrailingString(appendedPath, '/index.html') + search)});
               }
               // And if we should be serving a file and we're at the right path, we'll serve the file.
               return res.superstatic.handleFileStream({file: appendedPath}, appendedPathResult);

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 
 // We cannot redirect to "", redirect to "/" instead
 function noEmptyRedirect(redir) {
-  return {redirect: !redir.redirect ? "/" : redir.redirect};
+  return {redirect: !redir.redirect ? '/' : redir.redirect};
 }
 
 module.exports = function() {
@@ -61,7 +61,7 @@ module.exports = function() {
           }
           if (trailingSlashBehavior === false &&
               hasTrailingSlash &&
-              pathname != '/') { // No infinite redirects
+              pathname !== '/') { // No infinite redirects
             return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingSlash(pathname) + search}));
           }
           if (trailingSlashBehavior === true &&

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -10,6 +10,11 @@ var url = require('fast-url-parser');
 var pathutils = require('../utils/pathutils');
 var _ = require('lodash');
 
+// We cannot redirect to "", redirect to "/" instead
+function noEmptyRedirect(redir) {
+  return {redirect: !redir.redirect ? "/" : redir.redirect};
+}
+
 module.exports = function() {
   return function(req, res, next) {
     var config = req.superstatic;
@@ -35,7 +40,7 @@ module.exports = function() {
             if (trailingSlashBehavior === true) {
               redirPath = pathutils.addTrailingSlash(redirPath);
             }
-            return res.superstatic.handle({redirect: redirPath + search});
+            return res.superstatic.handle(noEmptyRedirect({redirect: redirPath + search}));
           }
         }
         return res.superstatic.handleFileStream({file: pathname}, result);
@@ -55,8 +60,9 @@ module.exports = function() {
             return res.superstatic.handle({redirect: pathutils.addTrailingSlash(pathname) + search});
           }
           if (trailingSlashBehavior === false &&
-              hasTrailingSlash) {
-            return res.superstatic.handle({redirect: pathutils.removeTrailingSlash(pathname) + search});
+              hasTrailingSlash &&
+              pathname != '/') { // No infinite redirects
+            return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingSlash(pathname) + search}));
           }
           if (trailingSlashBehavior === true &&
               !hasTrailingSlash) {
@@ -87,7 +93,7 @@ module.exports = function() {
                   hasTrailingSlash) {
                 // If we had a slash to begin with, and we could be serving a file without it, we'll remove the slash.
                 // (This works because we are in the cleanURL block.)
-                return res.superstatic.handle({redirect: pathutils.removeTrailingSlash(pathname) + search});
+                return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingSlash(pathname) + search}));
               }
               if (trailingSlashBehavior === true &&
                   !hasTrailingSlash) {
@@ -98,7 +104,7 @@ module.exports = function() {
               }
               // If we've gotten this far and still have `/index.html` on the end, we want to remove it from the URL.
               if (_.endsWith(appendedPath, '/index.html')) {
-                return res.superstatic.handle({redirect: pathutils.removeTrailingString(appendedPath, '/index.html') + search});
+                return res.superstatic.handle(noEmptyRedirect({redirect: pathutils.removeTrailingString(appendedPath, '/index.html') + search}));
               }
               // And if we should be serving a file and we're at the right path, we'll serve the file.
               return res.superstatic.handleFileStream({file: appendedPath}, appendedPathResult);


### PR DESCRIPTION
An empty Location header is an error in most cases, when redirecting to "no path" it should always be a "/".