### PR TITLE
updating update-notifier, a few deps

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -18,8 +18,7 @@ var notify = require('./update-notifier');
 var updateCheckInterval = 1000 * 60 * 60 * 24 * 7; // 1 week
 
 var notifier = updateNotifier({
-  packageName: pkg.name,
-  packageVersion: pkg.version,
+  pkg: pkg,
   updateCheckInterval: updateCheckInterval
 });
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rsvp": "^3.6.2",
     "string-length": "^1.0.0",
     "try-require": "^1.0.0",
-    "update-notifier": "^1.0.3"
+    "update-notifier": "^2.5.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
     "eslint": "^2.9.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",
-    "nsp": "^2.6.3",
+    "nsp": "^3.2.1",
     "request": "^2.81.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.12.0",
     "std-mocks": "^1.0.1",
-    "supertest": "^1.2.0"
+    "supertest": "^3.3.0"
   }
 }


### PR DESCRIPTION
`update-notifier` depended on an older version of things that included an old version of `got`, so this is to clean up those dependencies.

`nsp` and `supertest` were flagged by `npm audit`, so I upgraded those as well.