### PR TITLE
Travis Update, Removing nsp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
-  - 6
+  - '4'
+  - '6'
+  - '8'
   - stable
-env:
-  - CXX=g++-4.8 CXXFLAGS=-std=c++11
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-
-# script:
-  # - npm run outdated # list outdated modules (won't fail build)
-  # - npm run audit # validate against nodesecurity.io db, but don't fail the build.
+after_script:
+  - npm outdated
+  - npm audit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - '6'
   - '8'
   - stable
+script:
+  - npm test
+  - if [ $(npm --version | cut -d. -f1)" -ge 6 ]; then npm audit; else true; fi
 after_script:
   - npm outdated
-  - npm audit

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ node_js:
   - stable
 script:
   - npm test
-  - if [ $(npm --version | cut -d. -f1)" -ge 6 ]; then npm audit; else true; fi
+  - if [ $(npm --version | cut -d. -f1) -ge 6 ]; then npm audit; else true; fi
 after_script:
   - npm outdated

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "test-integration": "mocha test/integration/**",
     "lint": "eslint .",
     "coverage": "istanbul cover --print detail ./node_modules/.bin/_mocha -- test/unit/** test/integration/**",
-    "outdated": "npm outdated --depth 0",
-    "audit": "npm shrinkwrap --dev && nsp check || true && rm npm-shrinkwrap.json",
     "watch": "mocha -w test/unit/** test/integration/**"
   },
   "author": "Firebase (https://www.firebase.com/)",
@@ -77,7 +75,6 @@
     "eslint": "^2.9.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",
-    "nsp": "^3.2.1",
     "request": "^2.81.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.12.0",


### PR DESCRIPTION
Update for `.travis.yml`, mostly.

Remove some extra stuff that was unnecessary and removed `nsp`. `nsp` is replaced by `npm audit`, which only exists in `npm` >= `6`, so I added that as a check for when `npm` supports it.