### PR TITLE
Fixing `EINVAL` error when serving "/" on Windows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Error when attempting to serve "/" on Windows on a drive other than "C:\\"

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -88,7 +88,7 @@ module.exports = function(options) {
       result.stream = fs.createReadStream(foundPath);
       return result;
     }).catch(function(err) {
-      if (err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'EISDIR') {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'EISDIR' || err.code === 'EINVAL') {
         return null;
       }
       return RSVP.reject(err);


### PR DESCRIPTION
When serving content locally from a drive other than "C:\\" on Windows we would get `EINVAL` back as the error instead of the more expected `EISDIR` when the same thing is done on the "C:\\" drive.