### PR TITLE
BREAKING: bring superstatic up to requiring node >=8.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "bin": {
     "superstatic": "bin/server"
   },
+  "engines": {
+    "node": ">= 8.6.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/firebase/superstatic.git"


### PR DESCRIPTION
this is a breaking change to bring us up to current times.