### PR TITLE
return true (indicating we responded) on a 304 error

### DIFF
--- a/lib/responder.js
+++ b/lib/responder.js
@@ -139,6 +139,7 @@ Responder.prototype.handleNotModified = function() {
   this.res.removeHeader('Content-Length');
   this.res.removeHeader('Transfer-Encoding');
   this.res.end();
+  return true;
 };
 
 Responder.prototype.handleRedirect = function(redirect) {

--- a/test/unit/responder.spec.js
+++ b/test/unit/responder.spec.js
@@ -170,4 +170,13 @@ describe('Responder', function() {
       expect(responder.isNotModified(result)).to.be.false;
     });
   });
+
+  describe('#handleNotModified', function() {
+    it('should return true, indicating it responded', function() {
+      responder = new Responder({}, {removeHeader: _.noop, end: _.noop}, {});
+
+      var r = responder.handleNotModified();
+      expect(r).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/160236/94210863-d3286700-fe84-11ea-8c0c-30096314f886.png)

Turns out that handleStack expected `true` to be returned if we have responded to a request. In the 304 case, we were always returning `undefined` which meant the stack attempted to look for a 404 page.

This should address https://github.com/firebase/firebase-tools/issues/2610