### PR TITLE
add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ In this example, `/old/custom-segment/path` redirects to `/new/path/custom-segme
 }
 ```
 
+**i18n:** Internationalized content can be served based on `accept-language` or `x-country-code` headers.
+
+Imagine a setup with the following files:
+
+```
+- public/
+  - index.html
+  - i18n/
+    - fr/
+      - index.html
+```
+
+With `i18n` enabled, when a request is received for `/index.html` with the `accept-language` header set to `fr`, the content at `public/i18n/fr/index.html` will be returned as a response.
+
+For more information about how content is resolved when using `i18n`, see [the Firebase Hosting documentation of the feature](https://firebase.google.com/docs/hosting/i18n-rewrites).
+
+```json
+{
+  "i18n": {
+    "root": "/intl"
+  }
+}
+```
+
 ## API
 
 Superstatic is available as a middleware and a standalone [Connect](http://www.npmjs.org/package/connect) server. This means you can plug this into your current server or run your own static server using Superstatic's server.

--- a/README.md
+++ b/README.md
@@ -155,11 +155,17 @@ Imagine a setup with the following files:
 - public/
   - index.html
   - i18n/
+    - fr_ca/
+      - index.html
+    - ALL_ca/
+      - index.html
     - fr/
       - index.html
 ```
 
-With `i18n` enabled, when a request is received for `/index.html` with the `accept-language` header set to `fr`, the content at `public/i18n/fr/index.html` will be returned as a response.
+With `i18n` enabled, when a request is received for `/index.html` with the `accept-language` header set to `fr` (and no `x-country-code`), the content at `public/i18n/fr/index.html` will be returned as a response.
+
+If `accept-language: fr` and `x-country-code: ca` are passed, the content at `public/i18n/fr_ca/index.html` will be returned for `/index.html`.
 
 For more information about how content is resolved when using `i18n`, see [the Firebase Hosting documentation of the feature](https://firebase.google.com/docs/hosting/i18n-rewrites).
 

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -183,7 +183,6 @@ module.exports = function() {
 function providerResult(req, res, p) {
   return Promise.resolve()
     .then(() => {
-      console.error(req);
       const promises = [];
 
       const i18n = req.superstatic.i18n;

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -5,11 +5,16 @@
  * https://github.com/firebase/superstatic/blob/master/LICENSE
  */
 
-const url = require("fast-url-parser");
-const pathutils = require("../utils/pathutils");
 const _ = require("lodash");
+const pathjoin = require("join-path");
+const pathutils = require("../utils/pathutils");
+const url = require("fast-url-parser");
 
-// We cannot redirect to "", redirect to "/" instead
+/**
+ * We cannot redirect to "", redirect to "/" instead.
+ * @param {string} path path
+ * @return {string} noramlized path
+ */
 function normalizeRedirectPath(path) {
   return path || "/";
 }
@@ -26,8 +31,7 @@ module.exports = function() {
     const cleanUrlRules = !!_.get(req, "superstatic.cleanUrls");
 
     // Exact file always wins.
-    return res.superstatic
-      .provider(req, pathname)
+    return providerResult(req, res, pathname)
       .then((result) => {
         if (result) {
           // If we are using cleanURLs, we'll trim off any `.html` (or `/index.html`), if it exists.
@@ -37,7 +41,6 @@ module.exports = function() {
               if (_.endsWith(redirPath, "/index")) {
                 redirPath = pathutils.removeTrailingString(redirPath, "/index");
               }
-              // But if we need to keep the trailing slashes, we will do so.
               if (trailingSlashBehavior === true) {
                 redirPath = pathutils.addTrailingSlash(redirPath);
               }
@@ -56,9 +59,8 @@ module.exports = function() {
         const pathAsDirectoryWithIndex = pathutils.asDirectoryIndex(
           pathutils.addTrailingSlash(pathname)
         );
-        return res.superstatic
-          .provider(req, pathAsDirectoryWithIndex)
-          .then((pathAsDirectoryWithIndexResult) => {
+        return providerResult(req, res, pathAsDirectoryWithIndex).then(
+          (pathAsDirectoryWithIndexResult) => {
             // If an exact file wins now, we know that this path leads us to a directory.
             if (pathAsDirectoryWithIndexResult) {
               if (
@@ -109,9 +111,8 @@ module.exports = function() {
                 appendedPath += ".html";
               }
 
-              return res.superstatic
-                .provider(req, appendedPath)
-                .then((appendedPathResult) => {
+              return providerResult(req, res, appendedPath).then(
+                (appendedPathResult) => {
                   if (appendedPathResult) {
                     // Okay, back to trailing slash behavior
                     if (trailingSlashBehavior === false && hasTrailingSlash) {
@@ -157,14 +158,151 @@ module.exports = function() {
                   }
 
                   return next();
-                });
+                }
+              );
             }
 
             return next();
-          });
+          }
+        );
       })
       .catch((err) => {
         res.superstatic.handleError(err);
       });
   };
 };
+
+/**
+ * Uses the provider to look for a file given a path.
+ * This also takes into account i18n settings.
+ * @param {*} req
+ * @param {*} res
+ * @param {*} p the path to search for.
+ * @return {Promise<*>} a non-null value if a file is found.
+ */
+function providerResult(req, res, p) {
+  return Promise.resolve()
+    .then(() => {
+      console.error(req);
+      const promises = [];
+
+      const i18n = req.superstatic.i18n;
+      if (i18n && i18n.root) {
+        // The path order is:
+        // (1) root/language_country/path (for each language)
+        // (2) root/ALL_country/path (if country is set)
+        // (3) root/language_ALL/path or root/language/path (for each language)
+        const country = getCountryCode(req.headers);
+        const languages = getI18nLanguages(req.headers);
+        // (1)
+        if (country) {
+          for (const l of languages) {
+            promises.push(
+              res.superstatic.provider(
+                req,
+                pathjoin(i18n.root, `${l}_${country}`, p)
+              )
+            );
+          }
+          // (2)
+          promises.push(
+            res.superstatic.provider(
+              req,
+              pathjoin(i18n.root, `ALL_${country}`, p)
+            )
+          );
+        }
+        // (3)
+        for (const l of languages) {
+          promises.push(
+            res.superstatic.provider(req, pathjoin(i18n.root, `${l}_ALL`, p))
+          );
+          promises.push(
+            res.superstatic.provider(req, pathjoin(i18n.root, `${l}`, p))
+          );
+        }
+      }
+
+      promises.push(res.superstatic.provider(req, p));
+      return Promise.all(promises);
+    })
+    .then((results) => {
+      for (const r of results) {
+        if (r) {
+          return r;
+        }
+      }
+    });
+}
+
+/**
+ * Fetches the country code from the headers object.
+ * @param {object} headers
+ * @return {string} country code, or an empty string.
+ */
+function getCountryCode(headers) {
+  const overrideValue = cookieValue(
+    headers.cookie,
+    "firebase-country-override"
+  );
+  if (overrideValue) {
+    return overrideValue;
+  }
+  return headers["x-country-code"] || "";
+}
+
+/**
+ * Fetches the languages from the accept-language header.
+ * @param {object} headers
+ * @return {Array<string>} ordered list of languages from the header.
+ */
+function getI18nLanguages(headers) {
+  const overrideValue = cookieValue(
+    headers.cookie,
+    "firebase-language-override"
+  );
+  if (overrideValue) {
+    return overrideValue.includes(",")
+      ? overrideValue.split(",")
+      : [overrideValue];
+  }
+
+  const acceptLanguage = headers["accept-language"];
+  if (!acceptLanguage) {
+    return [];
+  }
+
+  const languagesSeen = {};
+  const languagesOrdered = [];
+  for (const v of acceptLanguage.split(",")) {
+    const l = v.split("-")[0];
+    if (!l) {
+      continue;
+    }
+    if (!languagesSeen[l]) {
+      languagesOrdered.push(l);
+    }
+    languagesSeen[l] = true;
+  }
+  return languagesOrdered;
+}
+
+/**
+ * Fetches a value from a cookie string.
+ * @param {*} cookieString full cookie string.
+ * @param {*} key key to look for.
+ * @return {string} the value.
+ */
+function cookieValue(cookieString, key) {
+  if (!cookieString) {
+    return "";
+  }
+  const cookies = cookieString.split(";").map((c) => c.trim());
+  for (const cookie of cookies) {
+    if (cookie.startsWith(key)) {
+      const s = cookie.split("=", 2);
+      return s.length === 2 ? s[1] : "";
+    }
+  }
+  return "";
+}

--- a/lib/middleware/files.js
+++ b/lib/middleware/files.js
@@ -177,7 +177,7 @@ module.exports = function() {
  * This also takes into account i18n settings.
  * @param {*} req
  * @param {*} res
- * @param {*} p the path to search for.
+ * @param {string} p the path to search for.
  * @return {Promise<*>} a non-null value if a file is found.
  */
 function providerResult(req, res, p) {
@@ -288,8 +288,8 @@ function getI18nLanguages(headers) {
 
 /**
  * Fetches a value from a cookie string.
- * @param {*} cookieString full cookie string.
- * @param {*} key key to look for.
+ * @param {string|undefined} cookieString full cookie string.
+ * @param {string} key key to look for.
  * @return {string} the value.
  */
 function cookieValue(cookieString, key) {

--- a/test/unit/middleware/files.spec.js
+++ b/test/unit/middleware/files.spec.js
@@ -152,8 +152,10 @@ describe("static server with trailing slash customization", () => {
     beforeEach(() => {
       fs.outputFileSync(".tmp/intl/es/index.html", "hola", "utf8");
       fs.outputFileSync(".tmp/intl/fr/index.html", "French Index!", "utf8");
+      fs.outputFileSync(".tmp/intl/jp_ALL/other.html", "Japanese!", "utf8");
       fs.outputFileSync(".tmp/intl/fr_ca/index.html", "French CA!", "utf8");
       fs.outputFileSync(".tmp/intl/ALL_ca/index.html", "Oh Canada", "utf8");
+      fs.outputFileSync(".tmp/intl/ALL_ca/hockey.html", "Only Canada", "utf8");
     });
 
     afterEach(() => {
@@ -190,6 +192,26 @@ describe("static server with trailing slash customization", () => {
         .end(done);
     });
 
+    it("should not show i18n content for other countries", (done) => {
+      app.use(files({ i18n: { root: "/intl" } }, { provider }));
+
+      request(app)
+        .get("/hockey.html")
+        .set("x-country-code", "jp")
+        .expect(404)
+        .end(done);
+    });
+
+    it("should allow i18n content specific to a country", (done) => {
+      app.use(files({ i18n: { root: "/intl" } }, { provider }));
+
+      request(app)
+        .get("/hockey.html")
+        .set("x-country-code", "ca")
+        .expect(200, "Only Canada")
+        .end(done);
+    });
+
     it("should resolve i18n content by accept-language and x-country-code", (done) => {
       app.use(files({ i18n: { root: "/intl" } }, { provider }));
 
@@ -223,6 +245,16 @@ describe("static server with trailing slash customization", () => {
           "firebase-language-override=fr; firebase-country-override=ca"
         )
         .expect(200, "French CA!")
+        .end(done);
+    });
+
+    it("should allow i18n resolution by language with _ALL", (done) => {
+      app.use(files({ i18n: { root: "/intl" } }, { provider }));
+
+      request(app)
+        .get("/other.html")
+        .set("accept-language", "jp")
+        .expect(200, "Japanese!")
         .end(done);
     });
   });


### PR DESCRIPTION
This adds i18n rewrite support for superstatic.

This can serve different content based on the `accept-language` or `x-country-code` headers. It also includes a way to override the language or country based on cookie values.