### PR TITLE
manually join paths instead of using the os sep

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+- Fixes issue with path resolution on Windows.

--- a/src/utils/pathutils.ts
+++ b/src/utils/pathutils.ts
@@ -19,8 +19,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { join } from "node:path";
-
 const INDEX_FILE = "index.html";
 
 /**
@@ -28,7 +26,10 @@ const INDEX_FILE = "index.html";
  * @return the path with "/index.html" appended, if required.
  */
 export function asDirectoryIndex(pathname: string): string {
-  return isDirectoryIndex(pathname) ? pathname : join(pathname, INDEX_FILE);
+  if (isDirectoryIndex(pathname)) {
+    return pathname;
+  }
+  return normalizeMultiSlashes(`${pathname}/${INDEX_FILE}`);
 }
 
 /**

--- a/test/unit/providers/fs.spec.ts
+++ b/test/unit/providers/fs.spec.ts
@@ -57,7 +57,7 @@ describe("provider: fs", () => {
     await fsp(opts)({}, "/index.html")
       .then(readStatStream)
       .then((body: string) => {
-        expect(body).to.eq("A\n");
+        expect(body.trim()).to.eq("A");
       });
   });
 
@@ -86,13 +86,13 @@ describe("provider: fs", () => {
       await fsp(opts)({}, "/index.html")
         .then(readStatStream)
         .then((body: string) => {
-          expect(body).to.eq("A\n");
+          expect(body.trim()).to.eq("A");
         });
 
       await fsp(opts)({}, "/b.html")
         .then(readStatStream)
         .then((body: string) => {
-          expect(body).to.eq("B\n");
+          expect(body.trim()).to.eq("B");
         });
     });
 


### PR DESCRIPTION
This fixes an issue where Windows users were getting Not Found issues.

I started working on fixing the tests in windows, but it's more tedious than I thought.