### PR TITLE
fs provider should return null if path has null bytes

### DIFF
--- a/src/providers/fs.ts
+++ b/src/providers/fs.ts
@@ -92,6 +92,7 @@ module.exports = function provider(options: any) {
       pathname.includes("../") ||
       pathname.includes("..\\") ||
       pathname.toLowerCase().includes("..%5c") ||
+      pathname.match(/\0/g) ||
       // A path that didn't start with a slash is not valid.
       !pathname.startsWith("/")
     ) {

--- a/test/unit/providers/fs.spec.ts
+++ b/test/unit/providers/fs.spec.ts
@@ -73,6 +73,10 @@ describe("provider: fs", () => {
     await expect(fsp(opts)({}, "/..%5Cb%5cb.html")).to.eventually.be.null;
   });
 
+  it("should return null if path has null bytes", async () => {
+    await expect(fsp(opts)({}, "/\0a.html")).to.eventually.be.null;
+  });
+
   it("should return null for a file that does not exist", async () => {
     await expect(fsp(opts)({}, "/bogus.html")).to.eventually.be.null;
   });


### PR DESCRIPTION
fixes: https://github.com/firebase/superstatic/issues/388