### PR TITLE
fast-url-parser -> url

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,1 @@
-
+* Switches from 'fast-url-parser' to Node's built-in URL parser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "compression": "^1.7.0",
         "connect": "^3.7.0",
         "destroy": "^1.0.4",
-        "fast-url-parser": "^1.1.3",
         "glob-slasher": "^1.0.1",
         "is-url": "^1.2.2",
         "join-path": "^1.1.1",
@@ -2979,14 +2978,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
@@ -5502,11 +5493,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/pupa": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "compression": "^1.7.0",
     "connect": "^3.7.0",
     "destroy": "^1.0.4",
-    "fast-url-parser": "^1.1.3",
     "glob-slasher": "^1.0.1",
     "is-url": "^1.2.2",
     "join-path": "^1.1.1",

--- a/src/middleware/files.js
+++ b/src/middleware/files.js
@@ -22,7 +22,7 @@
 const _ = require("lodash");
 const { i18nContentOptions } = require("../utils/i18n");
 const pathutils = require("../utils/pathutils");
-const url = require("fast-url-parser");
+const url = require("url");
 
 /**
  * We cannot redirect to "", redirect to "/" instead.
@@ -40,7 +40,7 @@ module.exports = function () {
 
     const parsedUrl = url.parse(req.url);
     const pathname = pathutils.normalizeMultiSlashes(parsedUrl.pathname);
-    const search = parsedUrl.search || "";
+    const search = parsedUrl.search ?? "";
 
     const cleanUrlRules = !!_.get(req, "superstatic.cleanUrls");
 

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -21,7 +21,7 @@
 
 const _ = require("lodash");
 const slasher = require("glob-slasher");
-const urlParser = require("fast-url-parser");
+const urlParser = require("url");
 const onHeaders = require("on-headers");
 const patterns = require("../utils/patterns");
 

--- a/src/middleware/rewrites.ts
+++ b/src/middleware/rewrites.ts
@@ -20,7 +20,7 @@
  */
 
 const slasher = require("glob-slasher"); // eslint-disable-line @typescript-eslint/no-var-requires
-const urlParser = require("fast-url-parser"); // eslint-disable-line @typescript-eslint/no-var-requires
+import * as urlParser from "url"; // eslint-disable-line @typescript-eslint/no-var-requires
 import { NextFunction } from "connect";
 import { IncomingMessage, ServerResponse } from "http";
 
@@ -50,7 +50,10 @@ module.exports = function () {
     next: NextFunction,
   ) {
     const rewrites = matcher(req.superstatic.rewrites ?? []);
-    const pathname: string = urlParser.parse(req.url).pathname;
+    if (!req.url) {
+      return next();
+    }
+    const pathname = urlParser.parse(req.url).pathname;
     const match = rewrites(slasher(pathname));
 
     if (!match) {


### PR DESCRIPTION
`fast-url-parser` was a faster drop in replacement for Node's builtin url parser. However, it hasn't been updated in 10 years, and uses `punycode` which is deprecated as of node 22. During those 10 years, node's built in parser has gotten much more efficient and so this is no longer necessary.