### PR TITLE
Added node 24

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,1 @@
-
+- Added Node 24 to engines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "typescript-eslint": "^8.23.0"
       },
       "engines": {
-        "node": "18 || 20 || 22"
+        "node": "18 || 20 || 22 || 24"
       },
       "optionalDependencies": {
         "re2": "^1.17.7"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "templates"
   ],
   "engines": {
-    "node": "18 || 20 || 22"
+    "node": "18 || 20 || 22 || 24"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding node 24 to our engines field.

Should we remove 18 too (which just went EOL) and make this a major update?